### PR TITLE
fix: avoid first-boot docker failure on arch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -129,9 +129,8 @@ install_packages() {
     sudo dnf install -y $packages
     ;;
   pacman)
-    sudo pacman -Syu --noconfirm
     # shellcheck disable=SC2086
-    sudo pacman -S --noconfirm $packages
+    sudo pacman -S --needed --noconfirm $packages
     ;;
   yum)
     # shellcheck disable=SC2086

--- a/roles/sysinit/tasks/tools/docker.yml
+++ b/roles/sysinit/tasks/tools/docker.yml
@@ -113,6 +113,21 @@
 - name: Docker - Flush handlers to ensure docker group is activated
   ansible.builtin.meta: flush_handlers
 
+- name: Docker - Check running kernel modules directory
+  ansible.builtin.stat:
+    path: "/lib/modules/{{ ansible_kernel }}"
+  register: docker_kernel_modules_dir
+
+- name: Docker - Fail clearly when reboot is required before Docker start
+  ansible.builtin.fail:
+    msg: >-
+      Docker cannot be started because the running kernel {{ ansible_kernel }}
+      does not have a matching modules directory at /lib/modules/{{ ansible_kernel }}.
+      A kernel package was likely upgraded during bootstrap, so reboot before retrying Docker startup.
+  when:
+    - ansible_facts['service_mgr'] == 'systemd'
+    - not docker_kernel_modules_dir.stat.exists
+
 - name: Docker - Enable and start Docker service
   when: ansible_facts['service_mgr'] == 'systemd'
   ansible.builtin.systemd:


### PR DESCRIPTION
Avoid performing a full pacman system upgrade during bootstrap so Docker is not started after a kernel/modules mismatch, and fail clearly if a reboot is still required before Docker startup.